### PR TITLE
Feature: relax requirements for data with predict or get draws

### DIFF
--- a/src/mrtool/core/cov_model.py
+++ b/src/mrtool/core/cov_model.py
@@ -13,6 +13,7 @@ import numpy as np
 from mrtool.core import utils
 from mrtool.core.data import MRData
 from numpy import ndarray
+from pandas import DataFrame
 from mrtool.core.prior import Prior, SplinePrior, default_prior_params
 from regmod.utils import SplineSpecs
 from xspline import XSpline
@@ -46,8 +47,8 @@ class Covariate:
     def is_empty(self) -> bool:
         return len(self.name) == 0
 
-    def get_mat(self, data: MRData) -> ndarray:
-        return data[self.name]
+    def get_mat(self, data: Union[DataFrame, MRData]) -> ndarray:
+        return np.asarray(data[self.name])
 
     def get_design_mat(self,
                        data: MRData,

--- a/src/mrtool/core/data.py
+++ b/src/mrtool/core/data.py
@@ -215,6 +215,9 @@ class MRData:
         self.df = df
         return other
 
+    def __contains__(self, col_name: str) -> bool:
+        return col_name in self.col_names
+
     def __repr__(self) -> str:
         name = type(self).__name__
         if self.is_empty:

--- a/src/mrtool/core/limetr_api.py
+++ b/src/mrtool/core/limetr_api.py
@@ -34,8 +34,8 @@ def get_limetr(model: "MRBRT") -> LimeTr:
     k_gamma = model.re_size
 
     # create x fun and z mat
-    x_fun, x_fun_jac = model.fe_fun
-    z_mat = model.re_mat
+    x_fun, x_fun_jac = model.get_fe_fun()
+    z_mat = model.get_re_mat()
 
     # priors
     uvec = model.get_priors("uprior")

--- a/src/mrtool/core/model.py
+++ b/src/mrtool/core/model.py
@@ -154,7 +154,8 @@ class MRBRT:
         self.data.df = df
         fe_fun, _ = self.fe_fun
         re_mat = self.re_mat
-        pred = self.soln.predict(fe_fun, re_mat, **kwargs)
+        group = self.data.group.values
+        pred = self.soln.predict(fe_fun, re_mat, group)
         self.data.df = self.df
         return pred
 
@@ -163,6 +164,7 @@ class MRBRT:
         self.data.df = df
         fe_fun, _ = self.fe_fun
         re_mat = self.re_mat
-        draws = self.soln.get_draws(fe_fun, re_mat, **kwargs)
+        group = self.data.group.values
+        draws = self.soln.get_draws(fe_fun, re_mat, group, **kwargs)
         self.data.df = self.df
         return draws

--- a/src/mrtool/core/model.py
+++ b/src/mrtool/core/model.py
@@ -112,9 +112,10 @@ class MRBRT:
     def size(self) -> int:
         return self.fe_size + self.re_size
 
-    @property
-    def fe_fun(self) -> Tuple[Callable, Callable]:
-        funs = [model.get_fun(self.data) for model in self.fe_cov_models]
+    def get_fe_fun(self, data: Union[DataFrame, MRData] = None) -> Tuple[Callable, Callable]:
+        if data is None:
+            data = self.data
+        funs = [model.get_fun(data) for model in self.fe_cov_models]
         funs, jac_funs = tuple(zip(*funs))
         indicies = utils.sizes_to_slices(self.fe_sizes)
 
@@ -127,11 +128,12 @@ class MRBRT:
                               for i, index in enumerate(indicies)])
         return fun, jac_fun
 
-    @property
-    def re_mat(self) -> ndarray:
+    def get_re_mat(self, data: Union[DataFrame, MRData] = None) -> ndarray:
+        if data is None:
+            data = self.data
         if len(self.re_cov_models) == 0:
-            return np.empty(shape=(self.data.shape[0], 0))
-        return np.hstack([model.get_mat() for model in self.re_cov_models])
+            return np.empty(shape=(data.shape[0], 0))
+        return np.hstack([model.get_mat(data) for model in self.re_cov_models])
 
     def get_priors(self, ptype: str):
         priors = [model.get_priors(ptype)
@@ -149,22 +151,19 @@ class MRBRT:
         self.df["is_outlier"] = (self.lt.w <= 0.1).astype(int)
         self.soln = get_soln(self)
 
-    def get_prediction(self, df: DataFrame = None, **kwargs) -> ndarray:
-        df = self.df if df is None else df
-        self.data.df = df
-        fe_fun, _ = self.fe_fun
-        re_mat = self.re_mat
-        group = self.data.group.values
-        pred = self.soln.predict(fe_fun, re_mat, group)
-        self.data.df = self.df
-        return pred
+    def extract_pred_data(self, data: Union[DataFrame, MRData] = None):
+        fe_fun, _ = self.get_fe_fun(data)
+        re_mat = self.get_re_mat(data)
+        if self.data.group.name in data:
+            group = data[self.data.group.name]
+        else:
+            group = np.array(["unknown"]*data.shape[0])
+        return fe_fun, re_mat, group
 
-    def get_draws(self, df: DataFrame = None, **kwargs) -> ndarray:
-        df = self.df if df is None else df
-        self.data.df = df
-        fe_fun, _ = self.fe_fun
-        re_mat = self.re_mat
-        group = self.data.group.values
-        draws = self.soln.get_draws(fe_fun, re_mat, group, **kwargs)
-        self.data.df = self.df
-        return draws
+    def get_prediction(self, data: Union[DataFrame, MRData] = None) -> ndarray:
+        return self.soln.predict(*self.extract_pred_data(data))
+
+    def get_draws(self,
+                  data: Union[DataFrame, MRData] = None,
+                  **kwargs) -> ndarray:
+        return self.soln.get_draws(*self.extract_pred_data(data), **kwargs)

--- a/tests/core/test_soln.py
+++ b/tests/core/test_soln.py
@@ -70,7 +70,7 @@ def test_sample_soln(soln, size, sample_beta, sample_gamma):
     assert soln.gamma_samples.shape == (size, soln.gamma.size)
 
 
-@pytest.mark.parametrize("group", [None, np.array(["a"]*200)])
+@pytest.mark.parametrize("group", [np.array(["a"]*200)])
 def test_predict(soln, fe_fun, re_mat, group):
     pred = soln.predict(fe_fun, re_mat, group)
     assert pred.size == 200
@@ -79,12 +79,12 @@ def test_predict(soln, fe_fun, re_mat, group):
 @pytest.mark.parametrize("size", [100])
 @pytest.mark.parametrize("sample_beta", [True, False])
 @pytest.mark.parametrize("sample_gamma", [True, False])
-@pytest.mark.parametrize("group", [None, np.array(["uknown"]*200)])
+@pytest.mark.parametrize("group", [np.array(["uknown"]*200)])
 @pytest.mark.parametrize("include_group_uncertainty", [True, False])
 def test_get_draws(soln, fe_fun, re_mat,
                    size, sample_beta, sample_gamma,
                    group, include_group_uncertainty):
-    draws = soln.get_draws(fe_fun, re_mat,
+    draws = soln.get_draws(fe_fun, re_mat, group,
                            size, sample_beta, sample_gamma,
-                           group, include_group_uncertainty)
+                           include_group_uncertainty)
     assert draws.shape == (size, 200)


### PR DESCRIPTION
The goal of this PR is to make the prediction and get draw easier

* add `__contains__` function in `MRData`, easier to see if contains columns
* change `group` from a keyword argument to an argument in `MRSoln`, simplify the logic flow
* change `fe_fun` and `re_mat` from property to function, and allow passing in data object
* add `extract_pred_data` function to easily extract the information needed for prediction and get draws.