### PR TITLE
Fix the warnings and errors in the reported in Github workflow

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -22,7 +22,7 @@ jobs:
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true
         user: __token__

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from setuptools import setup, find_packages
 
+from setuptools import find_packages, setup
 
 if __name__ == '__main__':
     base_dir = Path(__file__).parent
@@ -44,6 +44,7 @@ if __name__ == '__main__':
 
           description=about['__summary__'],
           long_description=long_description,
+          long_description_content_type='text/x-rst',
           license=about['__license__'],
           url=about['__uri__'],
 


### PR DESCRIPTION
* Change the `pypa/gh-action-pypi-publish@master` to `pypa/gh-action-pypi-publish@release/v1` more details see [here](https://github.com/pypa/gh-action-pypi-publish)
* Add `long_description_content_type='text/x-rst'` in the `setup.py`
* Add repository secret for uploading the package