### PR TITLE
Add categorical covariate model

### DIFF
--- a/src/mrtool/__init__.py
+++ b/src/mrtool/__init__.py
@@ -7,15 +7,25 @@ mrtool
 """
 
 from .core import utils
-from .core.cov_model import CovModel, LinearCovModel, LogCovModel
+from .core.cov_model import (
+    CatCovModel,
+    CovModel,
+    LinearCatCovModel,
+    LinearCovModel,
+    LogCatCovModel,
+    LogCovModel,
+)
 from .core.data import MRData
 from .core.model import MRBRT, MRBeRT
 from .cov_selection.covfinder import CovFinder
 
 __all__ = [
     "MRData",
+    "CatCovModel",
     "CovModel",
+    "LinearCatCovModel",
     "LinearCovModel",
+    "LogCatCovModel",
     "LogCovModel",
     "MRBRT",
     "MRBeRT",

--- a/src/mrtool/core/cov_model.py
+++ b/src/mrtool/core/cov_model.py
@@ -936,10 +936,7 @@ class LogCovModel(CovModel):
 
 
 class CatCovModel(CovModel):
-    """Categorical covariate model.
-
-    TODO: Add order prior.
-    """
+    """Categorical covariate model."""
 
     def __init__(
         self,
@@ -1018,7 +1015,27 @@ class CatCovModel(CovModel):
                     f"ref_cat {self.ref_cat} is not in the categories."
                 )
 
-        # TODO: set the uniform prior for ref_cat to zero
+        if self.ref_cat is not None:
+            ref_index = dict(zip(self.cats, self.cats.index))[self.ref_cat]
+            ref_beta_uprior = self.prior_beta_uniform[:, ref_index]
+            if not (
+                np.isinf(ref_beta_uprior).all()
+                or np.allclose(ref_beta_uprior, 0.0)
+            ):
+                warnings.warn(
+                    f"Reset ref_cat beta uniform prior from {ref_beta_uprior} to (0, 0)"
+                )
+            self.prior_beta_uniform[:, ref_index] = 0.0
+            if not self.use_re_intercept:
+                ref_gamma_uprior = self.prior_gamma_uniform[:, ref_index]
+                if not (
+                    np.isinf(ref_gamma_uprior[1]).all()
+                    or np.allclose(ref_gamma_uprior, 0.0)
+                ):
+                    warnings.warn(
+                        f"Reset ref_cat gamma uniform prior from {ref_gamma_uprior} to (0, 0)"
+                    )
+                self.prior_gamma_uniform[:, ref_index] = 0.0
 
         if self.prior_order is not None:
             for cat in set(

--- a/src/mrtool/core/cov_model.py
+++ b/src/mrtool/core/cov_model.py
@@ -945,6 +945,7 @@ class CatCovModel(CovModel):
         ref_cov=None,
         ref_cat=None,
         use_re=False,
+        use_re_intercept=False,
         prior_beta_gaussian=None,
         prior_beta_uniform=None,
         prior_beta_laplace=None,
@@ -965,6 +966,7 @@ class CatCovModel(CovModel):
             prior_gamma_laplace=prior_gamma_laplace,
         )
         self.ref_cat = ref_cat
+        self.use_re_intercept = use_re_intercept
         if len(self.alt_cov) != 1:
             raise ValueError("alt_cov should be a single column.")
         if len(self.ref_cov) > 1:
@@ -1026,11 +1028,13 @@ class CatCovModel(CovModel):
 
     @property
     def num_z_vars(self) -> int:
-        """Number of the random effects. Currently it is the same with the
-        number of the fixed effects, but this is to be discussed.
-        TODO: Overwrite the number of random effects.
+        """Number of the random effects. When use_re_intercept is set to True,
+        it will use a single intercept random effect. Otherwise, it will use
+        each category will have its own random effect.
 
         """
+        if self.use_re_intercept:
+            return 1
         return self.num_x_vars
 
     @property

--- a/src/mrtool/core/cov_model.py
+++ b/src/mrtool/core/cov_model.py
@@ -953,6 +953,8 @@ class CatCovModel(CovModel):
         prior_gamma_uniform=None,
         prior_gamma_laplace=None,
     ) -> None:
+        self.ref_cat = ref_cat
+        self.use_re_intercept = use_re_intercept
         super().__init__(
             alt_cov=alt_cov,
             name=name,
@@ -965,8 +967,7 @@ class CatCovModel(CovModel):
             prior_gamma_uniform=prior_gamma_uniform,
             prior_gamma_laplace=prior_gamma_laplace,
         )
-        self.ref_cat = ref_cat
-        self.use_re_intercept = use_re_intercept
+
         if len(self.alt_cov) != 1:
             raise ValueError("alt_cov should be a single column.")
         if len(self.ref_cov) > 1:

--- a/src/mrtool/core/data.py
+++ b/src/mrtool/core/data.py
@@ -91,7 +91,7 @@ class MRData:
         assert isinstance(self.covs, dict)
         for cov in self.covs.values():
             assert isinstance(cov, np.ndarray)
-            assert is_numeric_array(cov)
+            # assert is_numeric_array(cov)
 
     def _get_cov_scales(self):
         """Compute the covariate scale."""
@@ -103,6 +103,7 @@ class MRData:
             self.cov_scales = {
                 cov_name: np.max(np.abs(cov))
                 for cov_name, cov in self.covs.items()
+                if is_numeric_array(cov)
             }
             zero_covs = [
                 cov_name
@@ -159,12 +160,13 @@ class MRData:
         if not self.is_empty():
             index = np.full(self.num_obs, False)
             for cov_name, cov in self.covs.items():
-                cov_index = np.isnan(cov)
-                if cov_index.any():
-                    warnings.warn(
-                        f"There are {cov_index.sum()} nans in covaraite {cov_name}."
-                    )
-                index = index | cov_index
+                if is_numeric_array(cov):
+                    cov_index = np.isnan(cov)
+                    if cov_index.any():
+                        warnings.warn(
+                            f"There are {cov_index.sum()} nans in covaraite {cov_name}."
+                        )
+                    index = index | cov_index
             self._remove_data(index)
 
     def _remove_data(self, index: NDArray):

--- a/src/mrtool/core/model.py
+++ b/src/mrtool/core/model.py
@@ -51,6 +51,15 @@ class MRBRT:
             self.cov_names.extend(cov_model.covs)
         self.num_covs = len(self.cov_names)
 
+        # place holder for the limetr objective
+        self.lt: LimeTr
+        self.beta_soln: NDArray
+        self.gamma_soln: NDArray
+        self.u_soln: NDArray
+        self.w_soln: NDArray
+        self.re_soln: NDArray
+
+    def _infer_shape(self) -> None:
         # add random effects
         if not any([cov_model.use_re for cov_model in self.cov_models]):
             self.cov_models[0].use_re = True
@@ -82,14 +91,6 @@ class MRBRT:
         self.num_regularizations = sum(
             [cov_model.num_regularizations for cov_model in self.cov_models]
         )
-
-        # place holder for the limetr objective
-        self.lt: LimeTr
-        self.beta_soln: NDArray
-        self.gamma_soln: NDArray
-        self.u_soln: NDArray
-        self.w_soln: NDArray
-        self.re_soln: NDArray
 
     def attach_data(self, data=None):
         """Attach data to cov_model."""
@@ -239,6 +240,7 @@ class MRBRT:
         """
         if not all([cov_model.has_data() for cov_model in self.cov_models]):
             self.attach_data()
+        self._infer_shape()
 
         # dimensions
         n = self.data.study_sizes

--- a/src/mrtool/cov_selection/covfinder.py
+++ b/src/mrtool/cov_selection/covfinder.py
@@ -179,6 +179,8 @@ class CovFinder:
         model = MRBRT(
             self.data, cov_models=cov_models, inlier_pct=self.inlier_pct
         )
+        model.attach_data()
+        model._infer_shape()
         return model
 
     def fit_gaussian_model(self, covs: list[str]) -> MRBRT:

--- a/tests/test_cat_covmodel.py
+++ b/tests/test_cat_covmodel.py
@@ -64,6 +64,14 @@ def test_ref_cov(data):
     covmodel = CatCovModel(alt_cov="alt_cat")
     covmodel.attach_data(data)
     assert covmodel.ref_cat is None
+    assert np.isinf(covmodel.prior_beta_uniform).all()
+
+    covmodel = CatCovModel(alt_cov="alt_cat", use_re_intercept=False)
+    covmodel.attach_data(data)
+    assert covmodel.ref_cat is None
+    assert np.isinf(covmodel.prior_beta_uniform).all()
+    assert np.allclose(covmodel.prior_gamma_uniform[0], 0.0)
+    assert np.isposinf(covmodel.prior_gamma_uniform[1]).all()
 
     with pytest.warns():
         covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
@@ -71,9 +79,22 @@ def test_ref_cov(data):
     covmodel.attach_data(data)
     assert covmodel.ref_cat == "A"
 
-    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat", ref_cat="B")
+    covmodel = CatCovModel(
+        alt_cov="alt_cat",
+        ref_cov="ref_cat",
+        ref_cat="B",
+        use_re_intercept=False,
+    )
     covmodel.attach_data(data)
     assert covmodel.ref_cat == "B"
+    my_beta_uprior = np.array(
+        [[-np.inf, 0.0, -np.inf, -np.inf], [np.inf, 0.0, np.inf, np.inf]]
+    )
+    my_gamma_uprior = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [np.inf, 0.0, np.inf, np.inf]]
+    )
+    assert np.allclose(covmodel.prior_beta_uniform, my_beta_uprior)
+    assert np.allclose(covmodel.prior_gamma_uniform, my_gamma_uprior)
 
 
 def test_has_data(data):

--- a/tests/test_cat_covmodel.py
+++ b/tests/test_cat_covmodel.py
@@ -139,3 +139,31 @@ def test_create_design_mat(data):
             ]
         ),
     )
+
+
+def test_order_prior(data):
+    covmodel = CatCovModel(
+        alt_cov="alt_cat",
+        ref_cov="ref_cat",
+        ref_cat="A",
+        prior_order=[["A", "B"], ["B", "C"]],
+    )
+    covmodel.attach_data(data)
+    assert covmodel.prior_order == [("A", "B"), ("B", "C")]
+
+    covmodel = CatCovModel(
+        alt_cov="alt_cat",
+        ref_cov="ref_cat",
+        ref_cat="A",
+        prior_order=[["A", "B", "C"], ["B", "C"]],
+    )
+    assert covmodel.prior_order == [("A", "B"), ("B", "C")]
+
+    with pytest.raises(ValueError):
+        covmodel = CatCovModel(
+            alt_cov="alt_cat",
+            ref_cov="ref_cat",
+            ref_cat="A",
+            prior_order=[["A", "B"], ["B", "C", "E"]],
+        )
+        covmodel.attach_data(data)

--- a/tests/test_cat_covmodel.py
+++ b/tests/test_cat_covmodel.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from mrtool.core.cov_model import CatCovModel
+from mrtool.core.data import MRData
+
+
+@pytest.fixture
+def data():
+    df = pd.DataFrame(
+        dict(
+            obs=[0, 1, 0, 1],
+            obs_se=[0.1, 0.1, 0.1, 0.1],
+            alt_cat=["A", "A", "B", "C"],
+            ref_cat=["A", "B", "B", "D"],
+            study_id=[1, 1, 2, 2],
+        )
+    )
+    data = MRData()
+    data.load_df(
+        df,
+        col_obs="obs",
+        col_obs_se="obs_se",
+        col_covs=["alt_cat", "ref_cat"],
+        col_study_id="study_id",
+    )
+    return data
+
+
+def test_init():
+    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
+    assert covmodel.alt_cov == ["alt_cat"]
+    assert covmodel.ref_cov == ["ref_cat"]
+
+    covmodel = CatCovModel(alt_cov="alt_cat")
+    assert covmodel.alt_cov == ["alt_cat"]
+    assert covmodel.ref_cov == []
+
+    with pytest.raises(ValueError):
+        CatCovModel(alt_cov=["a", "b"])
+
+    with pytest.raises(ValueError):
+        CatCovModel(alt_cov="a", ref_cov=["a", "b"])
+
+
+def test_attach_data(data):
+    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
+    assert not hasattr(covmodel, "cats")
+    covmodel.attach_data(data)
+    assert covmodel.cats.to_list() == ["A", "B", "C", "D"]
+
+
+def test_has_data(data):
+    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
+    assert not covmodel.has_data()
+
+    covmodel.attach_data(data)
+    assert covmodel.has_data()
+
+
+def test_encode(data):
+    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
+    covmodel.attach_data(data)
+
+    mat = covmodel.encode(["A", "B", "C", "C"])
+    true_mat = np.array(
+        [
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ]
+        ]
+    )
+    assert np.allclose(mat, true_mat)
+
+
+def test_create_design_mat(data):
+    covmodel = CatCovModel(alt_cov="alt_cat", ref_cov="ref_cat")
+    covmodel.attach_data(data)
+
+    alt_mat, ref_mat = covmodel.create_design_mat(data)
+
+    assert np.allclose(
+        alt_mat,
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ]
+        ),
+    )
+
+    assert np.allclose(
+        ref_mat,
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    )


### PR DESCRIPTION
Add `CatCovModel` in the `mrtool.core.cov_model` module, this is try to process the categorical risks and potentially network analysis.

## Simple Example

Simulate data, here we simulate data with four categories, 10 studies and 10 observations per study.
```python
import itertools

import numpy as np
import pandas as pd

from mrtool import MRData, LinearCatCovModel, MRBRT

np.random.seed(0)
num_studies = 10
num_obs_per_study = 10
gamma = 0.1
obs_se = np.sqrt(0.1)

effects = pd.DataFrame(dict(cat=["A", "B", "C", "D"], effect=[0, 1, 2, 3]))
all_pairs = list(itertools.combinations(effects.cat, 2))
# sample pairs for each observation
pairs = [
    all_pairs[np.random.randint(0, len(all_pairs))]
    for _ in range(num_studies * num_obs_per_study)
]

df = pd.DataFrame(pairs, columns=["ref_cat", "alt_cat"])
df["study_id"] = np.repeat(range(num_studies), num_obs_per_study)
df["re"] = np.repeat(
    np.random.normal(0, scale=np.sqrt(gamma), size=num_studies), num_obs_per_study
)
df["obs_se"] = obs_se
df["noise"] = np.random.normal(scale=df["obs_se"])

# merge with the true effect sizes
df = df.merge(
    effects.rename(columns={"cat": "ref_cat", "effect": "ref_effect"}),
    on="ref_cat",
).merge(
    effects.rename(columns={"cat": "alt_cat", "effect": "alt_effect"}),
    on="alt_cat",
)

df["obs"] = df.eval("alt_effect - ref_effect + noise + re")

df.head(5)
```

Fit model
```python
data = MRData()
data.load_df(
    df,
    col_obs="obs",
    col_obs_se="obs_se",
    col_covs=["ref_cat", "alt_cat"],
    col_study_id="study_id",
)

covmodels = [
    LinearCatCovModel(
        alt_cov="alt_cat", ref_cov="ref_cat", ref_cat="A", use_re=True
    )
]

model = MRBRT(data, covmodels)

model.fit_model()

# check solution and compare with the truth
model.beta_soln # vs effects
model.gamma_soln # vs gamma
```