### PR TITLE
fixed create_model to attach data and infer shape

### DIFF
--- a/src/mrtool/cov_selection/covfinder.py
+++ b/src/mrtool/cov_selection/covfinder.py
@@ -179,6 +179,8 @@ class CovFinder:
         model = MRBRT(
             self.data, cov_models=cov_models, inlier_pct=self.inlier_pct
         )
+        model.attach_data()
+        model._infer_shape()
         return model
 
     def fit_gaussian_model(self, covs: list[str]) -> MRBRT:


### PR DESCRIPTION
Added two lines to create_model in CovFinder class so that mrbrt object has data attached and shape is inferred correctly (random and fixed effects, constraints, etc.).