### PR TITLE
Remove constraints on uniform gamma prior with category-specific gamma

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mrtool"
-version = "0.2.1"
+version = "0.2.2"
 description = "Featured nonlinear mixed effects model"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/mrtool/core/cov_model.py
+++ b/src/mrtool/core/cov_model.py
@@ -1027,16 +1027,6 @@ class CatCovModel(CovModel):
                     f"Reset ref_cat beta uniform prior from {ref_beta_uprior} to (0, 0)"
                 )
             self.prior_beta_uniform[:, ref_index] = 0.0
-            if self.use_re and (not self.use_re_intercept):
-                ref_gamma_uprior = self.prior_gamma_uniform[:, ref_index]
-                if not (
-                    np.isinf(ref_gamma_uprior[1]).all()
-                    or np.allclose(ref_gamma_uprior, 0.0)
-                ):
-                    warnings.warn(
-                        f"Reset ref_cat gamma uniform prior from {ref_gamma_uprior} to (0, 0)"
-                    )
-                self.prior_gamma_uniform[:, ref_index] = 0.0
 
         if self.prior_order is not None:
             for cat in set(

--- a/tests/test_cat_covmodel.py
+++ b/tests/test_cat_covmodel.py
@@ -93,11 +93,11 @@ def test_ref_cov(data):
     my_beta_uprior = np.array(
         [[-np.inf, 0.0, -np.inf, -np.inf], [np.inf, 0.0, np.inf, np.inf]]
     )
-    my_gamma_uprior = np.array(
-        [[0.0, 0.0, 0.0, 0.0], [np.inf, 0.0, np.inf, np.inf]]
-    )
+    # my_gamma_uprior = np.array(
+    #     [[0.0, 0.0, 0.0, 0.0], [np.inf, 0.0, np.inf, np.inf]]
+    # )
     assert np.allclose(covmodel.prior_beta_uniform, my_beta_uprior)
-    assert np.allclose(covmodel.prior_gamma_uniform, my_gamma_uprior)
+    # assert np.allclose(covmodel.prior_gamma_uniform, my_gamma_uprior)
 
 
 def test_has_data(data):


### PR DESCRIPTION
In the case where there is category-specific gamma, remove the uniform prior constraint forcing the reference category to have gamma = 0, so that model results are invariant to choice of reference category.

Let me know if it's okay to remove the relevant tests entirely (versus just commenting them out as I've done for now), and I will do so!